### PR TITLE
[2023.01.26] [index.html] [taeng0204] 각 페이지 별 css 파일 링크 동적으로 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="shortcut icon" href="./asset/Securious.jpg">
   <link rel="stylesheet" href="./css/styles.css">
-  <link rel="stylesheet" href="./css/html-1.css">
+  <link rel="stylesheet" id="pageStyle" href=" ">
   <title>Securious-MDN</title>
 </head>
 

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,12 @@
 const list = document.querySelectorAll('.list');
+const cssLink = document.getElementById("pageStyle");
 let selected = null;
+
+function changeStyle(url) {
+  if (cssLink) {
+    cssLink.href = "./css/" + url;
+  }
+}
 
 async function fetchHtmlAsText(url) {
   return await (await fetch("./html/" + url)).text();
@@ -9,7 +16,8 @@ async function importPage(event) {
   if (selected) selected.target.classList.remove("selected");
   selected = event;
   event.target.classList.add("selected");
-  document.querySelector('#main').innerHTML = await fetchHtmlAsText(event.target.id + '.html');
+  changeStyle(event.target.id + ".css")
+  document.querySelector('#main').innerHTML = await fetchHtmlAsText(event.target.id + ".html");
 }
 
 list.forEach((title) => (title.addEventListener("click", importPage)));


### PR DESCRIPTION
이전에 해결했던 방식으로 css파일을 한번에 불러오면 아래와 같은 단점이 있음
1. 새 페이지를 만들면 매번 index.html을 수정해야 한다.
2. 페이지가 많아질 수록 index.html이 불러오는 css 파일이 많아진다.
3. index.html에 중복으로 css 파일을 불러오게 되면 스타일이 겹칠 수 있다.

그래서 자바스크립트로 nav 클릭 시 동적으로 link의 href를 수정하게 하였다.
로컬 테스트는 성공적